### PR TITLE
Handle epithets containing `non`

### DIFF
--- a/ent/internal/preprocess/preprocess.go
+++ b/ent/internal/preprocess/preprocess.go
@@ -44,14 +44,11 @@ var AmbiguousException = map[string][]string{
 	"Eulaira":        {"dela"},
 	"Gnathopleustes": {"den"},
 	"Helophorus":     {"ser"},
-	"Hyacinthoides":  {"non-scripta"},
 	"Leptonetela":    {"la"},
 	"Malamatidia":    {"zu"},
 	"Meteorus":       {"dos"},
-	"Monocelis":      {"non-scripta"},
 	"Nocaracris":     {"van"},
 	"Paralvinella":   {"dela"},
-	"Peperomia":      {"non-alata"},
 	"Ruteloryctes":   {"bis"},
 	"Scoparia":       {"dela"},
 	"Selenops":       {"ab"},
@@ -68,7 +65,7 @@ var NoParseException = map[string]string{
 }
 
 var notesRe = regexp.MustCompile(
-	`(?i)\s+(environmental|samples|species\s+group|species\s+complex|clade|group|author|non|nec|vide|fide)\b.*$`,
+	`(?i)\s+((environmental|samples|species\s+group|species\s+complex|clade|group|author|nec|vide|fide)\b|non[^a-zA-Z-]).*$`,
 )
 var taxonConceptsRe1 = regexp.MustCompile(
 	`(?i)\s+(sero(var|type)|sensu|auct|sec|near|str)\.?\b.*$`,


### PR DESCRIPTION
This tiny PR removes the special cases of names with epithets containing `non` and updates the stopword regex to match only `non` that's not followed by `[a-zA-Z-]`.

It doesn't solve the `Xiphipops fisheri (non Snyder, 1904)` issue (i.e. that should perhaps be parsed), though, but I can open a new issue just for that if you think it's worth handling.